### PR TITLE
fix: `background-color` not `background color`

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <body>
   <style>
     body { 
-      background color: #000000;
+      background-color: #000000;
       color: #ffffff; 
     }
   </style>


### PR DESCRIPTION
This PR fixes a small typo which makes the “Rotisserie Chicken $5.99” text invisible in light modes.